### PR TITLE
Fix compatibility with ESPHome 2025.10+

### DIFF
--- a/components/uart/uart_component_esp32_arduino.cpp
+++ b/components/uart/uart_component_esp32_arduino.cpp
@@ -183,16 +183,8 @@ void ESP32ArduinoUARTComponent::flush() {
 }
 
 void ESP32ArduinoUARTComponent::check_logger_conflict() {
-#ifdef USE_LOGGER
-  if (this->hw_serial_ == nullptr || logger::global_logger->get_baud_rate() == 0) {
-    return;
-  }
-
-  if (this->hw_serial_ == logger::global_logger->get_hw_serial()) {
-    ESP_LOGW(TAG, "  You're using the same serial port for logging and the UART component. Please "
-                  "disable logging over the serial port by setting logger->baud_rate to 0.");
-  }
-#endif
+  // Logger conflict checking removed in ESPHome 2025.10+
+  // The logger API no longer exposes get_hw_serial() method
 }
 
 }  // namespace uart

--- a/components/uart/uart_component_esp8266.cpp
+++ b/components/uart/uart_component_esp8266.cpp
@@ -66,8 +66,7 @@ void ESP8266UartComponent::setup() {
       (rx_pin_ == nullptr || rx_pin_->get_pin() == 3)
 #ifdef USE_LOGGER
       // we will use UART0 if logger isn't using it in swapped mode
-      && (logger::global_logger->get_hw_serial() == nullptr ||
-          logger::global_logger->get_uart() != logger::UART_SELECTION_UART0_SWAP)
+      && (logger::global_logger->get_uart() != logger::UART_SELECTION_UART0_SWAP)
 #endif
   ) {
     this->hw_serial_ = &Serial;
@@ -78,8 +77,7 @@ void ESP8266UartComponent::setup() {
              (rx_pin_ == nullptr || rx_pin_->get_pin() == 13)
 #ifdef USE_LOGGER
              // we will use UART0 swapped if logger isn't using it in regular mode
-             && (logger::global_logger->get_hw_serial() == nullptr ||
-                 logger::global_logger->get_uart() != logger::UART_SELECTION_UART0)
+             && (logger::global_logger->get_uart() != logger::UART_SELECTION_UART0)
 #endif
   ) {
     this->hw_serial_ = &Serial;
@@ -118,16 +116,8 @@ void ESP8266UartComponent::dump_config() {
 }
 
 void ESP8266UartComponent::check_logger_conflict() {
-#ifdef USE_LOGGER
-  if (this->hw_serial_ == nullptr || logger::global_logger->get_baud_rate() == 0) {
-    return;
-  }
-
-  if (this->hw_serial_ == logger::global_logger->get_hw_serial()) {
-    ESP_LOGW(TAG, "  You're using the same serial port for logging and the UART component. Please "
-                  "disable logging over the serial port by setting logger->baud_rate to 0.");
-  }
-#endif
+  // Logger conflict checking removed in ESPHome 2025.10+
+  // The logger API no longer exposes get_hw_serial() method
 }
 
 void ESP8266UartComponent::write_array(const uint8_t *data, size_t len) {

--- a/components/uart/uart_component_libretiny.cpp
+++ b/components/uart/uart_component_libretiny.cpp
@@ -150,16 +150,8 @@ void LibreTinyUARTComponent::flush() {
 }
 
 void LibreTinyUARTComponent::check_logger_conflict() {
-#ifdef USE_LOGGER
-  if (this->hardware_idx_ == -1 || logger::global_logger->get_baud_rate() == 0) {
-    return;
-  }
-
-  if (this->serial_ == logger::global_logger->get_hw_serial()) {
-    ESP_LOGW(TAG, "  You're using the same serial port for logging and the UART component. Please "
-                  "disable logging over the serial port by setting logger->baud_rate to 0.");
-  }
-#endif
+  // Logger conflict checking removed in ESPHome 2025.10+
+  // The logger API no longer exposes get_hw_serial() method
 }
 
 }  // namespace uart


### PR DESCRIPTION
ESPHome 2025.10 removed the logger::global_logger->get_hw_serial() method from the Logger API. This commit updates the UART components to remove references to this deprecated method.

Changes:
- Updated check_logger_conflict() to empty implementations in:
  - uart_component_esp32_arduino.cpp
  - uart_component_libretiny.cpp
  - uart_component_esp8266.cpp
- Removed get_hw_serial() calls from ESP8266 UART setup logic

The check_logger_conflict() function must remain as it's a pure virtual method in the base UARTComponent class, but ESPHome 2025.10+ handles UART/logger conflicts internally.